### PR TITLE
Adds `display_order` metadata to match the input column order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,26 @@ Tests are organized by datatype in `tests/testthat/`:
 
 **Important**: Tests only verify that import completes or fails as expected - they do NOT validate output correctness.
 
+For cases where it's worth pinning a non-obvious invariant about the resulting study object, an optional `assert.R` file could be provided in a test directory. `test_examples.R` would source it and call `assert(study)` after a successful wrangling run. This is not needed for most tests.
+
+```r
+# Example: tests/testthat/isasimple/01-basic/assert.R
+assert <- function(study) {
+  entity <- study %>% get_entities() %>% .[[1]]
+  vars <- entity %>% get_variable_metadata() %>% filter(!is.na(display_order))
+  expect_equal(vars$display_order, seq_len(nrow(vars)))
+}
+```
+
+`test_examples.R` would need a small addition after `export_to_vdi`:
+
+```r
+assert_path <- file.path(example_dir, "assert.R")
+if (file.exists(assert_path)) {
+  local({ source(assert_path); assert(study) })
+}
+```
+
 **Current count**: 48 passing tests.
 
 ### Adding a New Datatype

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ if (file.exists(assert_path)) {
 4. The `wrangle()` function must:
    - Find and process input files
    - Create entities using study.wrangler functions
-   - Validate entities
+   - Optionally call `stop_if_entity_invalid(entity)` before assembling a study object — this surfaces entity-level problems as user-friendly validation errors rather than the generic fallback in `wrangle.R`
    - Return a study object via `study_from_entities(entities = list(...))`
 5. Add format documentation in `doc/<datatype>.md` for outreach
 

--- a/lib/R/wrangle-isasimple.R
+++ b/lib/R/wrangle-isasimple.R
@@ -42,6 +42,11 @@ wrangle <- function(input_dir) {
   user_columns <- setdiff(names(entity@data), "entity_id")
   entity <- entity %>% redetect_columns_as_variables(user_columns)
 
+  # Preserve input column order in the visualization system
+  for (i in seq_along(user_columns)) {
+    entity <- entity %>% set_variable_metadata(user_columns[[i]], display_order = i)
+  }
+
   # Infer lat/lng variable metadata for EDA
   entity <- entity %>% infer_geo_variables_for_eda()
 


### PR DESCRIPTION
Just a simple addition to `wrangle-isatab.R`

Added some documentation for Claude in case we want to add tests on the actual wrangled `study` object (currently all test cases are only required to pass `validate(study)`). Decided it was overkill for this small feature.