### PR TITLE
Upgrade to study-wrangler 1.0.40 and add round-trip encoding tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,27 +122,22 @@ Tests are organized by datatype in `tests/testthat/`:
 
 **Important**: Tests only verify that import completes or fails as expected - they do NOT validate output correctness.
 
-For cases where it's worth pinning a non-obvious invariant about the resulting study object, an optional `assert.R` file could be provided in a test directory. `test_examples.R` would source it and call `assert(study)` after a successful wrangling run. This is not needed for most tests.
+For cases where it's worth pinning a non-obvious invariant about the resulting study object or its exported cache files, an optional `assert.R` file can be provided in a test directory. `test_examples.R` sources it and calls `assert(study, output_dir)` after a successful export.
 
 ```r
-# Example: tests/testthat/isasimple/01-basic/assert.R
-assert <- function(study) {
-  entity <- study %>% get_entities() %>% .[[1]]
-  vars <- entity %>% get_variable_metadata() %>% filter(!is.na(display_order))
-  expect_equal(vars$display_order, seq_len(nrow(vars)))
+# Example: tests/testthat/isasimple/09-iso8859-OK/assert.R
+assert <- function(study, output_dir) {
+  cache_files <- list.files(output_dir, pattern = "attributevalue.*\\.cache$", full.names = TRUE)
+  stopifnot("No attributevalue cache found" = length(cache_files) > 0)
+  all_text <- paste(
+    sapply(cache_files, function(f) paste(readLines(f, encoding = "UTF-8", warn = FALSE), collapse = "\n")),
+    collapse = "\n"
+  )
+  expect_true(grepl("ü", all_text, fixed = TRUE), label = "ü preserved in cache")
 }
 ```
 
-`test_examples.R` would need a small addition after `export_to_vdi`:
-
-```r
-assert_path <- file.path(example_dir, "assert.R")
-if (file.exists(assert_path)) {
-  local({ source(assert_path); assert(study) })
-}
-```
-
-**Current count**: 48 passing tests.
+**Current count**: 63 passing tests (including 2 encoding tests with assert.R assertions).
 
 ### Adding a New Datatype
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,7 +181,7 @@ RUN git clone https://github.com/VEuPathDB/vdi-lib-plugin-eda.git \
     && cp lib/perl/VdiStudyHandlerCommon.pm /opt/veupathdb/lib/perl \
     && cp bin/* /opt/veupathdb/bin
 
-ARG STUDY_WRANGLER_GIT_REF="v1.0.38"
+ARG STUDY_WRANGLER_GIT_REF="v1.0.40"
 RUN R -e "remotes::install_github('VEuPathDB/study-wrangler', '${STUDY_WRANGLER_GIT_REF}', upgrade_dependencies=F)"
 
 # VDI PLUGIN SERVER

--- a/tests/testthat/isasimple/09-iso8859-OK/assert.R
+++ b/tests/testthat/isasimple/09-iso8859-OK/assert.R
@@ -1,0 +1,11 @@
+assert <- function(study, output_dir) {
+  cache_files <- list.files(output_dir, pattern = "attributevalue.*\\.cache$", full.names = TRUE)
+  stopifnot("No attributevalue cache found" = length(cache_files) > 0)
+  all_text <- paste(
+    sapply(cache_files, function(f) paste(readLines(f, encoding = "UTF-8", warn = FALSE), collapse = "\n")),
+    collapse = "\n"
+  )
+  expect_true(grepl("ü", all_text, fixed = TRUE), label = "ü (u-umlaut, ISO-8859-1 0xFC) preserved in cache")
+  expect_true(grepl("Å", all_text, fixed = TRUE), label = "Å (A-ring, ISO-8859-1 0xC5) preserved in cache")
+  expect_true(grepl("é", all_text, fixed = TRUE), label = "é (e-acute, ISO-8859-1 0xE9) preserved in cache")
+}

--- a/tests/testthat/isasimple/09-iso8859-OK/data.csv
+++ b/tests/testthat/isasimple/09-iso8859-OK/data.csv
@@ -1,0 +1,5 @@
+name,measurement,category
+Müller,25.3,A
+Ångström,18.7,B
+Martínez,42.1,A
+Lefévre,33.5,C

--- a/tests/testthat/isasimple/10-windows1252-OK/assert.R
+++ b/tests/testthat/isasimple/10-windows1252-OK/assert.R
@@ -1,0 +1,11 @@
+assert <- function(study, output_dir) {
+  cache_files <- list.files(output_dir, pattern = "attributevalue.*\\.cache$", full.names = TRUE)
+  stopifnot("No attributevalue cache found" = length(cache_files) > 0)
+  all_text <- paste(
+    sapply(cache_files, function(f) paste(readLines(f, encoding = "UTF-8", warn = FALSE), collapse = "\n")),
+    collapse = "\n"
+  )
+  expect_true(grepl("ü", all_text, fixed = TRUE), label = "ü (u-umlaut) preserved in cache")
+  # € is the euro sign, encoded as 0x80 in Windows-1252 — not present in ISO-8859-1
+  expect_true(grepl("€", all_text, fixed = TRUE), label = "€ (euro sign, Windows-1252 0x80) preserved in cache")
+}

--- a/tests/testthat/isasimple/10-windows1252-OK/data.csv
+++ b/tests/testthat/isasimple/10-windows1252-OK/data.csv
@@ -1,0 +1,4 @@
+name,price,unit
+Müller,25.30,€
+Schröder,18.70,€
+Martínez,42.10,€

--- a/tests/testthat/test_examples.R
+++ b/tests/testthat/test_examples.R
@@ -178,6 +178,11 @@ for (datatype in datatypes) {
                     "Missing required base files: {paste(missing_files, collapse=', ')}"
                   ))
                 }
+
+                assert_path <- file.path(example_dir, "assert.R")
+                if (file.exists(assert_path)) {
+                  local({ source(assert_path); assert(study, tmp_dir) })
+                }
               }
             } else {
               stop(glue::glue("Validation of study failed for '{datatype}/{example}'"))


### PR DESCRIPTION
In addition to the new tests, a **new test mechanism is added**. If you add an `assert.R` file in the test directory, defining a function `assert(study, output_dir)` you can test specific issues with the study object and VDI output artefacts.

Summary of what was done:

- **`tests/testthat/test_examples.R`** — wired up the assert.R hook: sources `assert.R` and calls `assert(study, tmp_dir)` after successful export, if the file exists
- **`tests/testthat/isasimple/09-iso8859-OK/data.csv`** — ISO-8859-1 encoded CSV with ü, Å, ö, í, é (using explicit byte literals to guarantee correct encoding)
- **`tests/testthat/isasimple/09-iso8859-OK/assert.R`** — checks that ü, Å, and é survive intact in the exported `attributevalue_*.cache` file
- **`tests/testthat/isasimple/10-windows1252-OK/data.csv`** — Windows-1252 encoded CSV with the same Latin characters plus € (0x80, the definitive Windows-1252-only byte)
- **`tests/testthat/isasimple/10-windows1252-OK/assert.R`** — checks for ü and the Windows-1252-specific €
- **`CLAUDE.md`** — updated assert.R signature to `assert(study, output_dir)` with a real example, and updated the test count to 63
