### PR TITLE
Fix non reporting of column issues in isasimple

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ assert <- function(study, output_dir) {
 }
 ```
 
-**Current count**: 65 passing tests (including 2 encoding tests with assert.R assertions).
+**Current count**: 67 passing tests (including 2 encoding tests with assert.R assertions).
 
 ### Adding a New Datatype
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ assert <- function(study, output_dir) {
 }
 ```
 
-**Current count**: 63 passing tests (including 2 encoding tests with assert.R assertions).
+**Current count**: 65 passing tests (including 2 encoding tests with assert.R assertions).
 
 ### Adding a New Datatype
 

--- a/lib/R/wrangle-isasimple.R
+++ b/lib/R/wrangle-isasimple.R
@@ -30,11 +30,20 @@ wrangle <- function(input_dir) {
 
   # Add serial ID column before type inference so entity_from_file detects it as the entity ID.
   # provider_label for each column is set automatically to the column name by sync_variable_metadata.
-  entity <- entity_from_file(
-    input_file,
-    name = "record",
-    preprocess_fn = function(data) {
-      data %>% mutate(entity_id = sprintf("entity%06d", seq_len(nrow(data))), .before = 1)
+  entity <- tryCatch(
+    entity_from_file(
+      input_file,
+      name = "record",
+      preprocess_fn = function(data) {
+        data %>% mutate(entity_id = sprintf("entity%06d", seq_len(nrow(data))), .before = 1)
+      }
+    ),
+    error = function(e) {
+      stop_validation_error(
+        user_msg = "Your data file could not be parsed. Please check that it is a valid TSV or CSV file where every row has the same number of columns as the header (use empty values rather than omitting them).",
+        technical_msg = conditionMessage(e),
+        file = input_file
+      )
     }
   )
 

--- a/tests/testthat/isasimple/11-cheeses-BAD/data.tsv
+++ b/tests/testthat/isasimple/11-cheeses-BAD/data.tsv
@@ -1,0 +1,31 @@
+cheese_name	country	region	latitude	longitude	milk_type	texture	age_months	fat_content_pct	protected_designation	blue_veined	avg_price_eur_kg
+Parmigiano-Reggiano	Italy	Emilia-Romagna	44.70	10.64	cow	hard	24	32.0	yes	no	28.50
+Brie de Meaux	France	Île-de-France	48.85	2.97	cow	soft	0.5	27.0	yes	no	18.00
+Manchego	Spain	La Mancha	39.40	-3.00	sheep	hard	12	31.5	yes	no	22.00
+Gruyère	Switzerland	Fribourg	46.58	7.07	cow	hard	10	33.0	yes	no	24.50
+Stilton	England	East Midlands	52.64	-0.71	cow	semi-hard		31.0	yes	yes	19.00
+Feta	Greece	Epirus	39.67	20.85	sheep	soft	2		yes	no
+Camembert de Normandie	France	Normandy	48.88	0.19	cow	soft	0.75	24.0	yes	no	16.50
+Roquefort	France	Aveyron	43.97	2.99	sheep	soft	3	31.5	yes	yes	32.00
+Edam	Netherlands	North Holland	52.51	5.05	cow	semi-hard	4	26.5	no	no	9.50
+Emmental	Switzerland	Bern	46.96	7.77	cow	hard	4	31.0	no	no	14.00
+Cheddar	England	Somerset	51.28	-2.78	cow	hard	12	34.0	no	no	11.00
+Mozzarella di Bufala	Italy	Campania	40.86	14.27	buffalo	fresh	0.1	22.0	yes	no	18.50
+Halloumi	Cyprus		35.16	33.36	sheep	semi-hard	0.5	25.0	yes	no	12.00
+Gorgonzola	Italy	Lombardy	45.53	9.40	cow	soft	3	31.0	yes	yes	21.00
+Comté	France	Franche-Comté	47.27	5.99	cow	hard	8	33.5	yes	no	26.00
+Appenzeller	Switzerland	Appenzell	47.33	9.41	cow	hard	3	31.0	no	no
+Jarlsberg	Norway	Vestfold	59.91	10.75	cow	semi-hard	3	27.0	no	no	13.50
+Manchego Curado	Spain	La Mancha	39.40	-3.00	sheep	hard	6	31.5	no	no	19.00
+Pecorino Romano	Italy	Lazio	41.90	12.49	sheep	hard	8	36.0	yes	no	17.00
+Limburger	Belgium	Liège	50.64	5.57	cow	soft	2	29.0	no	no	10.00
+Époisses	France	Burgundy	47.39	4.68	cow	soft	2	27.0	yes	no
+Gouda	Netherlands	South Holland	52.01	4.71	cow	semi-hard	6	30.5	no	no	10.50
+Taleggio	Italy	Lombardy	45.80	9.82	cow	soft	1.5	26.0	yes	no	16.00
+Ossau-Iraty	France	Basque Country	43.19	-0.75	sheep	semi-hard	3	30.0	yes	no	22.50
+Abbaye de Belloc	France	Pays Basque	43.42	-1.18	sheep	hard			no	no
+Havarti	Denmark	Zealand	55.46	11.77	cow	semi-hard	3	29.0	no	no	11.50
+Tilsit	Germany	Bavaria	48.14	11.58	cow	semi-hard	5	30.0	no	no	9.00
+Queijo Serra da Estrela	Portugal	Beira Interior	40.35	-7.63	sheep	soft	1.5		yes	no	28.00
+Graviera	Greece	Crete	35.34	25.13	sheep	hard	5	33.0	yes	no	14.00
+Vacherin Mont-d'Or	Switzerland	Vaud	46.52	6.23	cow	soft	1		yes	no	19.50

--- a/tests/testthat/isasimple/11-cheeses-BAD/vdi-meta.json
+++ b/tests/testthat/isasimple/11-cheeses-BAD/vdi-meta.json
@@ -1,0 +1,5 @@
+{
+  "test_expectation": "fail",
+  "expected_technical_error_regex": "Issues were encountered while parsing the file",
+  "expected_user_error_regex": "could not be parsed"
+}

--- a/tests/testthat/isasimple/11-cheeses-BAD/vdi-meta.json
+++ b/tests/testthat/isasimple/11-cheeses-BAD/vdi-meta.json
@@ -1,4 +1,5 @@
 {
+  "comment": "LLM-generated TSV where some rows are missing their trailing avg_price_eur_kg value (11 columns instead of 12). readr detects the column count mismatch and entity_from_tsv throws a parsing error. Tests that this is caught and reported as a validation error rather than an unexpected crash. See 12-cheeses-OK for the fixed version.",
   "test_expectation": "fail",
   "expected_technical_error_regex": "Issues were encountered while parsing the file",
   "expected_user_error_regex": "could not be parsed"

--- a/tests/testthat/isasimple/12-cheeses-OK/data.tsv
+++ b/tests/testthat/isasimple/12-cheeses-OK/data.tsv
@@ -1,0 +1,31 @@
+cheese_name	country	region	latitude	longitude	milk_type	texture	age_months	fat_content_pct	protected_designation	blue_veined	avg_price_eur_kg
+Parmigiano-Reggiano	Italy	Emilia-Romagna	44.7	10.64	cow	hard	24	32	yes	no	28.5
+Brie de Meaux	France	Ile-de-France	48.85	2.97	cow	soft	0.5	27	yes	no	18
+Manchego	Spain	La Mancha	39.4	-3	sheep	hard	12	31.5	yes	no	22
+Gruyere	Switzerland	Fribourg	46.58	7.07	cow	hard	10	33	yes	no	24.5
+Stilton	England	East Midlands	52.64	-0.71	cow	semi-hard		31	yes	yes	19
+Feta	Greece	Epirus	39.67	20.85	sheep	soft	2		yes	no	
+Camembert de Normandie	France	Normandy	48.88	0.19	cow	soft	0.75	24	yes	no	16.5
+Roquefort	France	Aveyron	43.97	2.99	sheep	soft	3	31.5	yes	yes	32
+Edam	Netherlands	North Holland	52.51	5.05	cow	semi-hard	4	26.5	no	no	9.5
+Emmental	Switzerland	Bern	46.96	7.77	cow	hard	4	31	no	no	14
+Cheddar	England	Somerset	51.28	-2.78	cow	hard	12	34	no	no	11
+Mozzarella di Bufala	Italy	Campania	40.86	14.27	buffalo	fresh	0.1	22	yes	no	18.5
+Halloumi	Cyprus		35.16	33.36	sheep	semi-hard	0.5	25	yes	no	12
+Gorgonzola	Italy	Lombardy	45.53	9.4	cow	soft	3	31	yes	yes	21
+Comte	France	Franche-Comte	47.27	5.99	cow	hard	8	33.5	yes	no	26
+Appenzeller	Switzerland	Appenzell	47.33	9.41	cow	hard	3	31	no	no	
+Jarlsberg	Norway	Vestfold	59.91	10.75	cow	semi-hard	3	27	no	no	13.5
+Manchego Curado	Spain	La Mancha	39.4	-3	sheep	hard	6	31.5	no	no	19
+Pecorino Romano	Italy	Lazio	41.9	12.49	sheep	hard	8	36	yes	no	17
+Limburger	Belgium	Liege	50.64	5.57	cow	soft	2	29	no	no	10
+Epoisses	France	Burgundy	47.39	4.68	cow	soft	2	27	yes	no	
+Gouda	Netherlands	South Holland	52.01	4.71	cow	semi-hard	6	30.5	no	no	10.5
+Taleggio	Italy	Lombardy	45.8	9.82	cow	soft	1.5	26	yes	no	16
+Ossau-Iraty	France	Basque Country	43.19	-0.75	sheep	semi-hard	3	30	yes	no	22.5
+Abbaye de Belloc	France	Pays Basque	43.42	-1.18	sheep	hard			no	no	
+Havarti	Denmark	Zealand	55.46	11.77	cow	semi-hard	3	29	no	no	11.5
+Tilsit	Germany	Bavaria	48.14	11.58	cow	semi-hard	5	30	no	no	9
+Queijo Serra da Estrela	Portugal	Beira Interior	40.35	-7.63	sheep	soft	1.5		yes	no	28
+Graviera	Greece	Crete	35.34	25.13	sheep	hard	5	33	yes	no	14
+Vacherin Mont-dOr	Switzerland	Vaud	46.52	6.23	cow	soft	1		yes	no	19.5

--- a/tests/testthat/isasimple/12-cheeses-OK/vdi-meta.json
+++ b/tests/testthat/isasimple/12-cheeses-OK/vdi-meta.json
@@ -1,0 +1,4 @@
+{
+  "comment": "Same cheese dataset as 11-cheeses-BAD, but generated programmatically in R (tribble + write_tsv) so every row is guaranteed to have all 12 columns. Missing values are represented as empty fields rather than omitted trailing tabs. Confirms the isasimple wrangler handles NAs in numeric columns correctly.",
+  "test_expectation": "pass"
+}


### PR DESCRIPTION
Added a known bad file and make sure the column mismatch is caught (crudely - the details only go into the logs) rather than nothing at all.

Also add a good cheeses file for use in website testing.